### PR TITLE
feat: add go support to lsp and formatters

### DIFF
--- a/lua/plugins/conform.lua
+++ b/lua/plugins/conform.lua
@@ -1,16 +1,17 @@
 return {
-	"stevearc/conform.nvim",
-	config = function()
-		require("conform").setup {
-			formatters_by_ft = {
-				lua = { "stylua" },
-				javascript = { "prettierd", "prettier", "biome", stop_after_first = true },
-				typescript = { "prettierd", "prettier", "biome", stop_after_first = true },
-			},
-			format_on_save = {
-				timeout_ms = 10000,
-				lsp_format = "fallback",
-			},
-		}
-	end,
+  "stevearc/conform.nvim",
+  config = function()
+    require("conform").setup({
+      formatters_by_ft = {
+        lua = { "stylua" },
+        go = { "goimports", "gofmt" },
+        javascript = { "prettierd", "prettier", "biome", stop_after_first = true },
+        typescript = { "prettierd", "prettier", "biome", stop_after_first = true },
+      },
+      format_on_save = {
+        timeout_ms = 10000,
+        lsp_format = "fallback",
+      },
+    })
+  end,
 }

--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -1,193 +1,205 @@
 return {
-	"neovim/nvim-lspconfig",
-	dependencies = {
-		"hrsh7th/nvim-cmp",
-		"hrsh7th/cmp-nvim-lsp",
-		"hrsh7th/cmp-buffer",
-		"nvim-lua/plenary.nvim",
-		"L3MON4D3/LuaSnip",
-		"luckasRanarison/tailwind-tools.nvim",
-		"onsails/lspkind-nvim",
-	},
-	event = { "BufReadPre", "BufNewFile" },
-	config = function()
-		---@diagnostic disable-next-line: unused-local
-		local lsp_attach = function(client, bufnr)
-			vim.api.nvim_create_autocmd({ "CursorHold", "CursorHoldI" }, {
-				buffer = bufnr,
-				callback = function()
-					require("nvim-lightbulb").update_lightbulb()
-				end,
-			})
+  "neovim/nvim-lspconfig",
+  dependencies = {
+    "hrsh7th/nvim-cmp",
+    "hrsh7th/cmp-nvim-lsp",
+    "hrsh7th/cmp-buffer",
+    "nvim-lua/plenary.nvim",
+    "L3MON4D3/LuaSnip",
+    "luckasRanarison/tailwind-tools.nvim",
+    "onsails/lspkind-nvim",
+  },
+  event = { "BufReadPre", "BufNewFile" },
+  config = function()
+    ---@diagnostic disable-next-line: unused-local
+    local lsp_attach = function(client, bufnr)
+      vim.api.nvim_create_autocmd({ "CursorHold", "CursorHoldI" }, {
+        buffer = bufnr,
+        callback = function()
+          require("nvim-lightbulb").update_lightbulb()
+        end,
+      })
 
-			if client.name == "tailwindcss" then
-				vim.api.nvim_create_autocmd("BufWritePost", {
-					buffer = bufnr,
-					callback = function()
-						vim.cmd("TailwindSort")
-					end,
-				})
-			end
+      if client.name == "tailwindcss" then
+        vim.api.nvim_create_autocmd("BufWritePost", {
+          buffer = bufnr,
+          callback = function()
+            vim.cmd("TailwindSort")
+          end,
+        })
+      end
 
-			local wk = require("which-key")
+      local wk = require("which-key")
 
-			wk.add {
-				{ "K", "<cmd>lua vim.lsp.buf.hover()<cr>" },
-			}
-		end
+      wk.add({
+        { "K", "<cmd>lua vim.lsp.buf.hover()<cr>" },
+      })
+    end
 
-		local capabilities = vim.lsp.protocol.make_client_capabilities()
+    local capabilities = vim.lsp.protocol.make_client_capabilities()
 
-		capabilities = require("cmp_nvim_lsp").default_capabilities(capabilities)
+    capabilities = require("cmp_nvim_lsp").default_capabilities(capabilities)
 
-		local lsp_options = {
-			capabilities = capabilities,
-			on_attach = lsp_attach,
-			single_file_support = true,
-		}
+    local lsp_options = {
+      capabilities = capabilities,
+      on_attach = lsp_attach,
+      single_file_support = true,
+    }
 
-		local lsp = require("lspconfig")
+    local lsp = require("lspconfig")
 
-		lsp.lua_ls.setup(vim.tbl_extend("force", lsp_options, {
-			settings = {
-				Lua = {
-					runtime = {
-						version = "LuaJIT",
-					},
-					diagnostics = {
-						globals = { "vim" },
-					},
-					workspace = {
-						library = {
-							vim.env.VIMRUNTIME,
-						},
-					},
-				},
-			},
-		}))
+    lsp.lua_ls.setup(vim.tbl_extend("force", lsp_options, {
+      settings = {
+        Lua = {
+          runtime = {
+            version = "LuaJIT",
+          },
+          diagnostics = {
+            globals = { "vim" },
+          },
+          workspace = {
+            library = {
+              vim.env.VIMRUNTIME,
+            },
+          },
+        },
+      },
+    }))
 
-		local mason_registry = require("mason-registry")
-		local vue_language_server_path = mason_registry.get_package("vue-language-server"):get_install_path()
-			.. "/node_modules/@vue/language-server"
+    local mason_registry = require("mason-registry")
+    local vue_language_server_path = mason_registry.get_package("vue-language-server"):get_install_path()
+      .. "/node_modules/@vue/language-server"
 
-		lsp.ts_ls.setup(vim.tbl_extend("force", lsp_options, {
-			init_options = {
-				plugins = {
-					{
-						name = "@vue/typescript-plugin",
-						location = vue_language_server_path,
-						languages = { "vue" },
-					},
-				},
-			},
-			filetypes = { "typescript", "javascript", "javascriptreact", "typescriptreact", "vue" },
-		}))
+    lsp.ts_ls.setup(vim.tbl_extend("force", lsp_options, {
+      init_options = {
+        plugins = {
+          {
+            name = "@vue/typescript-plugin",
+            location = vue_language_server_path,
+            languages = { "vue" },
+          },
+        },
+      },
+      filetypes = { "typescript", "javascript", "javascriptreact", "typescriptreact", "vue" },
+    }))
 
-		lsp.tailwindcss.setup(vim.tbl_extend("force", lsp_options, {
-			settings = {
-				tailwindCSS = {
-					includeLanguages = {
-						elixir = "html-eex",
-						eelixir = "html-eex",
-						heex = "html-eex",
-					},
-					emmetCompletions = true,
-					experimental = {
-						classRegex = {
-							'class[:]\\s*"([^"]*)"',
-						},
-					},
-				},
-			},
-		}))
+    lsp.tailwindcss.setup(vim.tbl_extend("force", lsp_options, {
+      settings = {
+        tailwindCSS = {
+          includeLanguages = {
+            elixir = "html-eex",
+            eelixir = "html-eex",
+            heex = "html-eex",
+          },
+          emmetCompletions = true,
+          experimental = {
+            classRegex = {
+              'class[:]\\s*"([^"]*)"',
+            },
+          },
+        },
+      },
+    }))
 
-		lsp.elixirls.setup(vim.tbl_extend("force", lsp_options, {
-			cmd = { "elixir-ls" },
-			settings = { elixirLS = { dialyzerEnabled = false } },
-		}))
+    lsp.elixirls.setup(vim.tbl_extend("force", lsp_options, {
+      cmd = { "elixir-ls" },
+      settings = { elixirLS = { dialyzerEnabled = false } },
+    }))
 
-		lsp.biome.setup(vim.tbl_extend("force", lsp_options, {
-			filetypes = { "typescript", "javascript", "javascriptreact", "typescriptreact", "vue" },
-		}))
+    lsp.gopls.setup({
+      settings = {
+        gopls = {
+          analyses = {
+            unusedparams = true,
+          },
+          staticcheck = true,
+          gofumpt = true,
+        },
+      },
+    })
 
-		lsp.volar.setup(lsp_options)
+    lsp.biome.setup(vim.tbl_extend("force", lsp_options, {
+      filetypes = { "typescript", "javascript", "javascriptreact", "typescriptreact", "vue" },
+    }))
 
-		lsp.emmet_language_server.setup(vim.tbl_extend("force", lsp_options, {
-			init_options = {
-				includeLanguages = {
-					elixir = "html-eex",
-					eelixir = "html-eex",
-					heex = "html-eex",
-					eex = "html-eex",
-				},
-			},
-			filetypes = {
-				"css",
-				"eelixir",
-				"elixir",
-				"heex",
-				"html",
-				"javascript",
-				"javascriptreact",
-				"less",
-				"sass",
-				"scss",
-				"pug",
-				"typescriptreact",
-			},
-		}))
+    lsp.volar.setup(lsp_options)
 
-		local cmp = require("cmp")
-		local luasnip = require("luasnip")
+    lsp.emmet_language_server.setup(vim.tbl_extend("force", lsp_options, {
+      init_options = {
+        includeLanguages = {
+          elixir = "html-eex",
+          eelixir = "html-eex",
+          heex = "html-eex",
+          eex = "html-eex",
+        },
+      },
+      filetypes = {
+        "css",
+        "eelixir",
+        "elixir",
+        "heex",
+        "html",
+        "javascript",
+        "javascriptreact",
+        "less",
+        "sass",
+        "scss",
+        "pug",
+        "typescriptreact",
+      },
+    }))
 
-		cmp.setup {
-			preselect = "item",
-			completion = {
-				completeopt = "menu,menuone,noinsert",
-			},
-			snippet = {
-				expand = function(args)
-					luasnip.lsp_expand(args.body)
-				end,
-			},
-			mapping = cmp.mapping.preset.insert {
-				["<C-d>"] = cmp.mapping.scroll_docs(-4),
-				["<C-f>"] = cmp.mapping.scroll_docs(4),
-				["<C-Space>"] = cmp.mapping.complete {},
-				["<CR>"] = cmp.mapping.confirm {
-					behavior = cmp.ConfirmBehavior.Replace,
-					select = true,
-				},
-				["<Tab>"] = cmp.mapping(function(fallback)
-					if cmp.visible() then
-						cmp.select_next_item()
-					elseif luasnip.expand_or_jumpable() then
-						luasnip.expand_or_jump()
-					else
-						fallback()
-					end
-				end, { "i", "s" }),
-				["<S-Tab>"] = cmp.mapping(function(fallback)
-					if cmp.visible() then
-						cmp.select_prev_item()
-					elseif luasnip.jumpable(-1) then
-						luasnip.jump(-1)
-					else
-						fallback()
-					end
-				end, { "i", "s" }),
-			},
-			sources = {
-				{ name = "nvim_lsp" },
-				{ name = "luasnip" },
-				{ name = "buffer" },
-			},
-			formatting = {
-				format = require("lspkind").cmp_format {
-					mode = "symbol",
-					before = require("tailwind-tools.cmp").lspkind_format,
-				},
-			},
-		}
-	end,
+    local cmp = require("cmp")
+    local luasnip = require("luasnip")
+
+    cmp.setup({
+      preselect = "item",
+      completion = {
+        completeopt = "menu,menuone,noinsert",
+      },
+      snippet = {
+        expand = function(args)
+          luasnip.lsp_expand(args.body)
+        end,
+      },
+      mapping = cmp.mapping.preset.insert({
+        ["<C-d>"] = cmp.mapping.scroll_docs(-4),
+        ["<C-f>"] = cmp.mapping.scroll_docs(4),
+        ["<C-Space>"] = cmp.mapping.complete({}),
+        ["<CR>"] = cmp.mapping.confirm({
+          behavior = cmp.ConfirmBehavior.Replace,
+          select = true,
+        }),
+        ["<Tab>"] = cmp.mapping(function(fallback)
+          if cmp.visible() then
+            cmp.select_next_item()
+          elseif luasnip.expand_or_jumpable() then
+            luasnip.expand_or_jump()
+          else
+            fallback()
+          end
+        end, { "i", "s" }),
+        ["<S-Tab>"] = cmp.mapping(function(fallback)
+          if cmp.visible() then
+            cmp.select_prev_item()
+          elseif luasnip.jumpable(-1) then
+            luasnip.jump(-1)
+          else
+            fallback()
+          end
+        end, { "i", "s" }),
+      }),
+      sources = {
+        { name = "nvim_lsp" },
+        { name = "luasnip" },
+        { name = "buffer" },
+      },
+      formatting = {
+        format = require("lspkind").cmp_format({
+          mode = "symbol",
+          before = require("tailwind-tools.cmp").lspkind_format,
+        }),
+      },
+    })
+  end,
 }

--- a/lua/plugins/mason.lua
+++ b/lua/plugins/mason.lua
@@ -1,23 +1,24 @@
 return {
-	"williamboman/mason.nvim",
-	dependencies = {
-		"WhoIsSethDaniel/mason-tool-installer.nvim",
-		"williamboman/mason-lspconfig.nvim",
-	},
-	config = function()
-		require("mason").setup {}
-		require("mason-tool-installer").setup {
-			ensure_installed = {
-				"biome",
-				"emmet-language-server",
-				"elixirls",
-				-- "eslint",
-				"lua_ls",
-				"volar",
-				"stylua",
-				"tailwindcss",
-				"typescript-language-server",
-			},
-		}
-	end,
+  "williamboman/mason.nvim",
+  dependencies = {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    "williamboman/mason-lspconfig.nvim",
+  },
+  config = function()
+    require("mason").setup({})
+    require("mason-tool-installer").setup({
+      ensure_installed = {
+        "biome",
+        "emmet-language-server",
+        "elixirls",
+        -- "eslint",
+        "gopls",
+        "lua_ls",
+        "volar",
+        "stylua",
+        "tailwindcss",
+        "typescript-language-server",
+      },
+    })
+  end,
 }


### PR DESCRIPTION
- added `go` formatter support in `conform.lua` for improved formatting of go files.
- integrated `gopls` lsp configuration in `lsp.lua` to enhance development experience for go projects.
- updated `mason.lua` to ensure `gopls` is installed for seamless setup of go language server.